### PR TITLE
Adiciona matcher golang com algoritmo iterador

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+
+jobs:
+
+  tests_golang:
+    working_directory: ~/deploy
+    docker:
+      - image: circleci/golang
+    steps:
+      - checkout
+
+      - run:
+          name: test go packages
+          command: go test ./...
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - tests_golang

--- a/linear-golang/pkg/model/answers.go
+++ b/linear-golang/pkg/model/answers.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"encoding/json"
+		)
+
+//Answers represents a set of answers from an individual
+type Answers map[string][]int8
+
+func (t *Answers) UnmarshalJSON(b []byte) error {
+	var answersAsString map[string][]string
+
+	err := json.Unmarshal(b, &answersAsString)
+	if err != nil {
+		return err
+	}
+
+	toInt := map[string]int8{
+		"CP": 2,
+		"C": 1,
+		"I": 0,
+		"D": -1,
+		"DP": -2,
+	}
+
+	*t = make(map[string][]int8)
+
+	for id,answers := range answersAsString {
+		intAnswers := make([]int8, len(answers))
+		for i,answer := range answers {
+			intAnswers[i] = toInt[answer]
+		}
+		(*t)[id] = intAnswers
+	}
+
+	return nil
+}

--- a/linear-golang/pkg/model/scores.go
+++ b/linear-golang/pkg/model/scores.go
@@ -1,0 +1,12 @@
+package model
+
+type MatchScore struct {
+	CandidateId string
+	Score       int
+}
+
+type MatchScoreList []MatchScore
+
+func (s MatchScoreList) Len() int { return len(s) }
+func (s MatchScoreList) Less(i, j int) bool { return s[i].Score < s[j].Score }
+func (s MatchScoreList) Swap(i, j int){ s[i], s[j] = s[j], s[i] }

--- a/linear-golang/pkg/service/scorer.go
+++ b/linear-golang/pkg/service/scorer.go
@@ -1,0 +1,20 @@
+package service
+
+func Score(candidateAnswers []int8, electorAnswers []int8)  int{
+	var score int
+	for i := 0; i < len(candidateAnswers); i++ {
+		if electorAnswers[i] == 0 {
+			continue
+		}
+		if candidateAnswers[i] == electorAnswers[i] {
+			score += 2
+			continue
+		}
+		if candidateAnswers[i] * electorAnswers[i] > 0 {
+			score += 1
+			continue
+		}
+	}
+
+	return score
+}

--- a/linear-golang/pkg/service/scorer_test.go
+++ b/linear-golang/pkg/service/scorer_test.go
@@ -1,0 +1,47 @@
+package service_test
+
+import (
+		"testing"
+				. "../service"
+)
+
+var scoreTests = []struct {
+	candidateAnswers  []int8
+	electorAnswers  []int8
+	expectedScore int
+}{
+	{[]int8{2}, []int8{2}, 2},
+	{[]int8{1}, []int8{2}, 1},
+	{[]int8{-1}, []int8{2}, 0},
+	{[]int8{-2}, []int8{2}, 0},
+	{[]int8{2}, []int8{1}, 1},
+	{[]int8{1}, []int8{1}, 2},
+	{[]int8{-1}, []int8{1}, 0},
+	{[]int8{-2}, []int8{1}, 0},
+	{[]int8{2}, []int8{0}, 0},
+	{[]int8{1}, []int8{0}, 0},
+	{[]int8{-1}, []int8{0}, 0},
+	{[]int8{-2}, []int8{0}, 0},
+	{[]int8{2}, []int8{-1}, 0},
+	{[]int8{1}, []int8{-1}, 0},
+	{[]int8{-1}, []int8{-1}, 2},
+	{[]int8{-2}, []int8{-1}, 1},
+	{[]int8{2}, []int8{-2}, 0},
+	{[]int8{1}, []int8{-2}, 0},
+	{[]int8{-1}, []int8{-2}, 1},
+	{[]int8{-2}, []int8{-2}, 2},
+}
+
+func TestScoring(t *testing.T)  {
+	for _,testData := range scoreTests {
+
+
+		expectedScore := testData.expectedScore
+		actualScore := Score(testData.candidateAnswers, testData.electorAnswers)
+
+		if actualScore != expectedScore {
+			t.Errorf("Expected score %d for candidate %q and elector %q, got %d", expectedScore, testData.candidateAnswers, testData.electorAnswers, actualScore)
+		}
+	}
+
+}

--- a/linear-golang/votasp_matcher.go
+++ b/linear-golang/votasp_matcher.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"io/ioutil"
+	"encoding/json"
+	"./pkg/model"
+	"time"
+	"log"
+	"./pkg/service"
+	"sort"
+	)
+
+func main() {
+	rawCandidatesAnswers, err := ioutil.ReadFile(os.Args[1]); if err != nil {
+		panic(err)
+	}
+
+	rawElectorsAnswers, err := ioutil.ReadFile(os.Args[2]); if err != nil {
+		panic(err)
+	}
+    var candidatesAnswers model.Answers
+    json.Unmarshal(rawCandidatesAnswers, &candidatesAnswers)
+
+	var electorsAnswers model.Answers
+	json.Unmarshal(rawElectorsAnswers, &electorsAnswers)
+
+	start := time.Now()
+
+	for _,electorAnswers := range electorsAnswers {
+		candidatesScores := make(model.MatchScoreList, len(candidatesAnswers))
+		for candidateId,candidateAnswers := range candidatesAnswers {
+			score := service.Score(candidateAnswers, electorAnswers)
+			candidatesScores = append(candidatesScores, model.MatchScore{candidateId, score})
+		}
+		sort.Sort(candidatesScores)
+		//topTen := candidatesScores[len(candidatesScores)-10:]
+	}
+
+	elapsed := time.Since(start)
+	log.Printf("Took %s to match %d elector answers with %d candidate answers", elapsed,len(electorsAnswers), len(candidatesAnswers))
+
+}
+


### PR DESCRIPTION
Só rodei alguns testes preliminares, mas já mostram que a solução é inviável:

* Took 4.264090765s to match 10000 elector answers with 1000 candidate answers
* Took 28.016056412s to match 10000 elector answers with 5000 candidate answers

Alguns exemplos de top-10 pontuaçõs de usuários, lembrando que os dados usados aqui são uma distribuição totalmente aleatória de respostas, e não necessariamente serão tão baixos em uma aplicação real:
```json
{"c-3448": 40, "c-2534": 40, "c-4480": 41, "c-321": 41, "c-4901": 42, "c-546": 42, "c-59": 42, "c-3907": 42, "c-5": 45, "c-1912": 47}
```
```json
* {"c-4029": 40, "c-3944": 40, "c-2343": 40, "c-2784": 40, "c-3313": 40, "c-1455": 41, "c-3185": 41, "c-4190": 42, "c-4458": 43, "c-1486": 43}
```
```json
* {"c-2521": 35, "c-3355": 35, "c-3361": 35, "c-921": 35, "c-4907": 36, "c-1089": 36, "c-4618": 36, "c-2471": 36, "c-3412": 37, "c-3481": 37}
```

`c-****` é o identificador do candidato, e em frente a pontuação. Lembrando que a pontuação máxima é 80.
